### PR TITLE
1.8.3

### DIFF
--- a/generators/app/templates/app/build.gradle.kts
+++ b/generators/app/templates/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.application")
     kotlin("android")
     kotlin("kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -26,6 +27,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 
     sourceSets {
@@ -122,7 +124,7 @@ dependencies {
     //Glide
     implementation(libs.glide)
     implementation(libs.glide.okhttp)
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.compiler)
 
     //RxJava
     implementation(libs.rx.android)

--- a/generators/app/templates/build.gradle.kts
+++ b/generators/app/templates/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.gradlePlugin) apply false
+    alias(libs.plugins.ksp) apply false
 }
 
 tasks.register("clean",Delete::class){

--- a/generators/app/templates/gradle.properties
+++ b/generators/app/templates/gradle.properties
@@ -19,6 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/generators/app/templates/gradle/libs.versions.toml
+++ b/generators/app/templates/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
-kotlin = "1.8.0"
-androidGradlePlugin = "8.1.4"
+kotlin = "1.9.22"
+ksp = "1.9.22-1.0.16"
+androidGradlePlugin = "8.2.1"
 androidxAppCompat = "1.6.1"
 androidxCore = "1.12.0"
 androidxConstraintlayout = "2.1.4"
-material = "1.10.0"
+material = "1.11.0"
 sdpAndroid = "1.0.4"
 androidxRecyclerview = "1.3.2"
 androidxCardview = "1.0.0"
@@ -24,8 +25,8 @@ rxAndroid = "2.1.1"
 rxJava = "2.2.9"
 retrofit = "2.9.0"
 okhttp = "4.9.0"
-okio = "2.8.0"
-dagger = "2.41"
+okio = "2.9.0"
+dagger = "2.50"
 javaxAnnotation = "10.0-b28"
 
 [libraries]
@@ -75,3 +76,4 @@ javax-annotation = { group = "org.glassfish", name = "javax.annotation", version
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/generators/app/templates/gradle/wrapper/gradle-wrapper.properties
+++ b/generators/app/templates/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
     "minAndroidSDK": "26",
     "targetAndroidSDK": "34",
-    "kotlin": "1.8.0",
-    "agp": "8.1.4",
+    "kotlin": "1.9.22",
+    "agp": "8.2.1",
     "yeoman": "5.6.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-android-kotlin-mvvm",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Android Boilerplate Code with Kotlin & MVVM",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- AGP to 8.2.1
- kotlin to 1.9.22
- material to 1.11.0
- okio to 2.9.0
- dagger to 2.50
- add example usage of KSP on glide library